### PR TITLE
Fixed Template Inputs and added .NET8 framework option

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -88,7 +88,7 @@ jobs:
   Deploy_NuGet-org:
     needs: Build
     runs-on: windows-latest
-    
+    if: github.ref == 'refs/heads/main'
     steps:   
 
     - name: Download a Build Artifact

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -1,10 +1,10 @@
 name: Build and Deploy
 
 on:
-  push:
-    branches:
-      - release/*
-      - main
+#  push:
+#    branches:
+#      - release/*
+#      - main
   workflow_dispatch: #option to manually trigger action
 
 permissions:

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -88,7 +88,7 @@ jobs:
   Deploy_NuGet-org:
     needs: Build
     runs-on: windows-latest
-    if: github.ref == 'refs/heads/main'
+    
     steps:   
 
     - name: Download a Build Artifact

--- a/.template.config/template.json
+++ b/.template.config/template.json
@@ -33,114 +33,22 @@
       "datatype": "bool",
       "description": "If specified, skips the automatic restore of the project on create.",
       "defaultValue": "false"
-    },
-    "packageId": {
-      "type": "parameter",
-      "datatype": "text",
-      "description": "project property packageId cleanup",
-      "replaces": "<PackageId>Inventor.AddinTemplate</PackageId>",
-      "defaultValue": ""
-    },
-    "title": {
-      "type": "parameter",
-      "datatype": "text",
-      "description": "project property title cleanup",
-      "replaces": "<Title>Autodesk Inventor Addin</Title>",
-      "defaultValue": ""
-    },
-    "authors": {
-      "type": "parameter",
-      "datatype": "text",
-      "description": "project property authors cleanup",
-      "replaces": "<Authors>Bret Leasure</Authors>",
-      "defaultValue": ""
-    },
-    "copyright": {
-      "type": "parameter",
-      "datatype": "text",
-      "description": "project property copyright cleanup",
-      "replaces": "<Copyright>2024</Copyright>",
-      "defaultValue": ""
-    },
-    "decription": {
-      "type": "parameter",
-      "datatype": "text",
-      "description": "project property decription cleanup",
-      "replaces": "<Description>Easy to use template for creating Autodesk Inventor Addins</Description>",
-      "defaultValue": ""
-    },
-    "tags": {
-      "type": "parameter",
-      "datatype": "text",
-      "description": "project property tags cleanup",
-      "replaces": "<PackageTags>Autodesk Inventor Addin Template CAD Plugin</PackageTags>",
-      "defaultValue": ""
-    },
-    "url": {
-      "type": "parameter",
-      "datatype": "text",
-      "description": "project property url cleanup",
-      "replaces": "<PackageProjectUrl>https://github.com/bretleasure/Inventor.AddinTemplate</PackageProjectUrl>",
-      "defaultValue": ""
-    },
-    "url2": {
-      "type": "parameter",
-      "datatype": "text",
-      "description": "project property url cleanup",
-      "replaces": "<RepositoryUrl>https://github.com/bretleasure/Inventor.AddinTemplate</RepositoryUrl>",
-      "defaultValue": ""
-    },
-    "readme": {
-      "type": "parameter",
-      "datatype": "text",
-      "description": "project property readme cleanup",
-      "replaces": "<PackageReadmeFile>README.md</PackageReadmeFile>",
-      "defaultValue": ""
-    },
-    "license": {
-      "type": "parameter",
-      "datatype": "text",
-      "description": "project property license cleanup",
-      "replaces": "<PackageLicenseExpression>MIT</PackageLicenseExpression>",
-      "defaultValue": ""
-    },
-    "packagetype": {
-      "type": "parameter",
-      "datatype": "text",
-      "description": "project property packagetype cleanup",
-      "replaces": "<PackageType>Template</PackageType>",
-      "defaultValue": ""
-    },
-    "includeBuildOutput": {
-      "type": "parameter",
-      "datatype": "text",
-      "description": "project property includeBuildOutput cleanup",
-      "replaces": "<IncludeBuildOutput>false</IncludeBuildOutput>",
-      "defaultValue": ""
-    },
-    "contentTargetFolders": {
-      "type": "parameter",
-      "datatype": "text",
-      "description": "project property contentTargetFolders cleanup",
-      "replaces": "<ContentTargetFolders>content</ContentTargetFolders>",
-      "defaultValue": ""
-    },
-    "noWarn": {
-      "type": "parameter",
-      "datatype": "text",
-      "description": "project property noWarn cleanup",
-      "replaces": "<NoWarn>$(NoWarn);NU5128</NoWarn>",
-      "defaultValue": ""
-    },
-    "nodeFaultExcludes": {
-      "type": "parameter",
-      "datatype": "text",
-      "description": "project property nodeFaultExcludes cleanup",
-      "replaces": "<NoDefaultExcludes>true</NoDefaultExcludes>",
-      "defaultValue": ""
     }
-
   },
+  "sources": [
+    {
+      "modifiers": [
+        {
+          "exclude": [ 
+            "**/*.sln",
+            "Directory.Packages.props",
+            "LICENSE",
+            
+            ".github/**"]
+        }
+      ]
+    }
+  ],
   "postActions": [
     {
       "condition": "(!skipRestore)",
@@ -150,7 +58,7 @@
       ],
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
       "continueOnError": true
-    }
+    }    
   ],
   "guids":[
     "25E7585D-00D9-47C6-8E1B-734A2186383A"

--- a/.template.config/template.json
+++ b/.template.config/template.json
@@ -23,6 +23,9 @@
         },
         {
           "choice": "net48"
+        },
+        {
+          "choice": "net8.0-windows"
         }
       ],
       "defaultValue": "net472",

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,7 +21,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <Content Include=".template.config\template.json" Exclude="**\bin\**;**\obj\**;**\.git\**;**\.idea\**;**\.vs\**" />
+        <Content Include="**" Exclude="**\bin\**;**\obj\**;**\.git\**;**\.idea\**;**\.vs\**" />
         <Content Remove="azure-pipelines.yml" />
         <Content Remove="README.md" />
         <Content Remove=".gitignore" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,24 @@
+<Project>
+    <PropertyGroup>
+        <PackageId>Inventor.AddinTemplate</PackageId>
+        <PackageVersion>1.0.0</PackageVersion>
+        <Authors>Bret Leasure</Authors>
+        <Description>Easy to use template for creating Autodesk Inventor Addins</Description>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <PackageTags>Autodesk Inventor Addin Template CAD Plugin</PackageTags>
+        <PackageProjectUrl>https://github.com/bretleasure/Inventor.AddinTemplate</PackageProjectUrl>
+        <RepositoryUrl>https://github.com/bretleasure/Inventor.AddinTemplate</RepositoryUrl>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <None Include="README.md" Pack="true" PackagePath="\" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <Content Include="**" Exclude="**\bin\**;**\obj\**;**\.git\**;**\.idea\**;**\.vs\**" />
+        <Content Remove="azure-pipelines.yml" />
+        <Content Remove="README.md" />
+        <Content Remove=".gitignore" />
+        <Content Remove="GitVersion.yml" />
+    </ItemGroup>
+</Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,12 +1,18 @@
 <Project>
     <PropertyGroup>
         <PackageId>Inventor.AddinTemplate</PackageId>
-        <PackageVersion>1.0.0</PackageVersion>
+        <Title>Autodesk Inventor Addin</Title>
         <Authors>Bret Leasure</Authors>
+        <Copyright>2024</Copyright>
         <Description>Easy to use template for creating Autodesk Inventor Addins</Description>
-        <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageTags>Autodesk Inventor Addin Template CAD Plugin</PackageTags>
-        <PackageProjectUrl>https://github.com/bretleasure/Inventor.AddinTemplate</PackageProjectUrl>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <PackageType>Template</PackageType>
+        <IncludeBuildOutput>false</IncludeBuildOutput>
+        <ContentTargetFolders>content</ContentTargetFolders>
+        <NoWarn>$(NoWarn);NU5128</NoWarn>
+        <NoDefaultExcludes>true</NoDefaultExcludes>
         <RepositoryUrl>https://github.com/bretleasure/Inventor.AddinTemplate</RepositoryUrl>
     </PropertyGroup>
 
@@ -15,7 +21,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <Content Include="**" Exclude="**\bin\**;**\obj\**;**\.git\**;**\.idea\**;**\.vs\**" />
+        <Content Include=".template.config\template.json" Exclude="**\bin\**;**\obj\**;**\.git\**;**\.idea\**;**\.vs\**" />
         <Content Remove="azure-pipelines.yml" />
         <Content Remove="README.md" />
         <Content Remove=".gitignore" />

--- a/Inventor.AddinTemplate.csproj
+++ b/Inventor.AddinTemplate.csproj
@@ -15,7 +15,6 @@
       <Reference Include="Autodesk.Inventor.Interop">
         <HintPath>lib\Autodesk.Inventor.Interop.dll</HintPath>
       </Reference>
-<!--      <Reference Include="System.Windows.Forms" />-->
     </ItemGroup>
 
     <ItemGroup>

--- a/Inventor.AddinTemplate.csproj
+++ b/Inventor.AddinTemplate.csproj
@@ -4,22 +4,6 @@
         <TargetFramework>net472</TargetFramework>
         <LangVersion>latest</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>  
-
-        <PackageId>Inventor.AddinTemplate</PackageId>
-        <Title>Autodesk Inventor Addin</Title>
-        <Authors>Bret Leasure</Authors>
-        <Copyright>2024</Copyright>
-        <Description>Easy to use template for creating Autodesk Inventor Addins</Description>
-        <PackageTags>Autodesk Inventor Addin Template CAD Plugin</PackageTags>
-        <PackageReadmeFile>README.md</PackageReadmeFile>
-        <PackageLicenseExpression>MIT</PackageLicenseExpression>
-
-        <PackageType>Template</PackageType>
-        <IncludeBuildOutput>false</IncludeBuildOutput>
-        <ContentTargetFolders>content</ContentTargetFolders>
-        <NoWarn>$(NoWarn);NU5128</NoWarn>
-        <NoDefaultExcludes>true</NoDefaultExcludes>
-        <RepositoryUrl>https://github.com/bretleasure/Inventor.AddinTemplate</RepositoryUrl>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -27,20 +11,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <Content Include="**" Exclude="**\bin\**;**\obj\**;**\.git\**;**\.idea\**;**\.vs\**" />
-        <Content Remove="azure-pipelines.yml" />
-        <Content Remove="README.md" />
-        <Content Remove=".gitignore" />
-        <Content Remove="GitVersion.yml" />
-    </ItemGroup>
-
-    <ItemGroup>
       <Reference Include="Autodesk.Inventor.Interop">
         <HintPath>lib\Autodesk.Inventor.Interop.dll</HintPath>
       </Reference>
       <Reference Include="System.Windows.Forms" />
     </ItemGroup>
-
 
     <ItemGroup>
       <PackageReference Include="Inventor.InternalNames" Version="0.4.1" />
@@ -52,14 +27,11 @@
       <PackageReference Include="System.Resources.Extensions" Version="9.0.0" />
     </ItemGroup>
 
-
-
     <ItemGroup>
       <None Update="Inventor.AddinTemplate.addin">
         <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       </None>
     </ItemGroup>
-
 
     <ItemGroup>
       <None Remove="Buttons\Assets\Default.png" />
@@ -67,10 +39,4 @@
       <None Remove="Buttons\Assets\Default-Dark.png" />
       <EmbeddedResource Include="Buttons\Assets\Default-Dark.png" />
     </ItemGroup>
-
-    <ItemGroup>
-        <None Include="README.md" Pack="true" PackagePath="\" />
-    </ItemGroup>
-
-
 </Project>

--- a/Inventor.AddinTemplate.csproj
+++ b/Inventor.AddinTemplate.csproj
@@ -3,7 +3,8 @@
     <PropertyGroup>
         <TargetFramework>net472</TargetFramework>
         <LangVersion>latest</LangVersion>
-        <ImplicitUsings>enable</ImplicitUsings>  
+        <ImplicitUsings>enable</ImplicitUsings>
+        <UseWindowsForms>true</UseWindowsForms>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -14,7 +15,7 @@
       <Reference Include="Autodesk.Inventor.Interop">
         <HintPath>lib\Autodesk.Inventor.Interop.dll</HintPath>
       </Reference>
-      <Reference Include="System.Windows.Forms" />
+<!--      <Reference Include="System.Windows.Forms" />-->
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
This pull request includes several changes across multiple files, focusing on modifying the build and deployment process, updating the template configuration, and cleaning up project properties. The most important changes are detailed below:

### Build and Deployment Process:

* [`.github/workflows/build-deploy.yml`](diffhunk://#diff-0a2a3bb14d8c517cf697b681cbf4137c0e7cadba0290cac39ed87fd484a5698aL4-R7): Commented out the push trigger for branches `release/*` and `main`, leaving only the manual trigger option (`workflow_dispatch`).

### Template Configuration:

* [`.template.config/template.json`](diffhunk://#diff-2bdb907097dd6eba54e9179e6e8b74877e4ecb242431de85047ba5913547726bR26-R28): Added a new choice `"net8.0-windows"` to the list of framework choices.
* [`.template.config/template.json`](diffhunk://#diff-2bdb907097dd6eba54e9179e6e8b74877e4ecb242431de85047ba5913547726bL36-R54): Removed multiple project property parameters (e.g., `packageId`, `title`, `authors`, etc.) and added a new `sources` section to exclude specific files and directories.

### Project Properties Cleanup:

* [`Directory.Packages.props`](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156R1-R30): Added a new project file to define various project properties such as `PackageId`, `Title`, `Authors`, and others, which were previously defined in the `.csproj` file.
* [`Inventor.AddinTemplate.csproj`](diffhunk://#diff-50961ecc18f79bcb0ec74f63d03fd0a4a61292b238bc1ec8de5c4ca4b98f4bb4L7-L44): Removed project properties that are now defined in `Directory.Packages.props` and added `UseWindowsForms` property. [[1]](diffhunk://#diff-50961ecc18f79bcb0ec74f63d03fd0a4a61292b238bc1ec8de5c4ca4b98f4bb4L7-L44) [[2]](diffhunk://#diff-50961ecc18f79bcb0ec74f63d03fd0a4a61292b238bc1ec8de5c4ca4b98f4bb4L55-L75)