### PR TITLE
Resolved issue of all files being Content build action, causing WPF Windows to have compile errors

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,6 +18,10 @@
 
     <ItemGroup>
         <None Include="README.md" Pack="true" PackagePath="\" />
+        
     </ItemGroup>
 
+    <ItemGroup>
+        <Content Include="**" Exclude="**\bin\**;**\obj\**;**\.git\**;**\.idea\**;**\.vs\**;**\*.sln;" />
+    </ItemGroup>
 </Project>

--- a/Inventor.AddinTemplate.csproj
+++ b/Inventor.AddinTemplate.csproj
@@ -34,13 +34,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <None Remove="Buttons\Assets\Default.png" />
       <EmbeddedResource Include="Buttons\Assets\Default-Light.png" />
-      <None Remove="Buttons\Assets\Default-Dark.png" />
       <EmbeddedResource Include="Buttons\Assets\Default-Dark.png" />
-    </ItemGroup>
-
-    <ItemGroup>
-        <Content Include="**" Exclude="**\bin\**;**\obj\**;**\.git\**;**\.idea\**;**\.vs\**;" />
-    </ItemGroup>
+    </ItemGroup>    
 </Project>


### PR DESCRIPTION
The <Content Include="**" being in the project file was causing issues with Wpf forms that need to have a Build Action of Page to work properly.