### PR TITLE
Removed stdole package reference

### DIFF
--- a/Inventor.AddinTemplate.csproj
+++ b/Inventor.AddinTemplate.csproj
@@ -23,7 +23,6 @@
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
-      <PackageReference Include="stdole" Version="17.14.40260" />
       <PackageReference Include="System.Resources.Extensions" Version="9.0.8" />
     </ItemGroup>
 


### PR DESCRIPTION
-Version mismatch between the referenced version and the version in Inventor was causing addin to crash
-Fixes #39 